### PR TITLE
Fix duplicate Request exports

### DIFF
--- a/cfg.json
+++ b/cfg.json
@@ -14,7 +14,8 @@
     	    "paramNaming": "original",
             "npmName": "FlotiqApi",
 	    "apiNameSuffix":"",
-	    "apiNamePrefix":""
+	    "apiNamePrefix":"",
+	    "prefixParameterInterfaces": true
 	},
 	"removeOperationIdPrefix": true,
     	"templateDir": "templates"


### PR DESCRIPTION
Original configuration results in an error when generating `d.ts` declarations:

```
src/apis/index.ts:5:1 - error TS2308: Module './ContentEvent' has already exported a member named 'GetRequest'. Consider explicitly re-exporting to resolve the ambiguity.

5 export * from './ContentTagInternal';
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This fix is based on https://github.com/OpenAPITools/openapi-generator/issues/1998