### PR TITLE
change API name suffix, add cleanup to standard flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ To generate a set of `d.ts` files for Typescript follow these steps:
 
 1. Execute `npx flotiq-codegen-ts generate` as usual
 2. Go to `./flotiqApi` directory
-3. Execute `../clean_duplicate_import.sh`
-4. Execute `npm run build`
+3. Execute `npm run build`
 
 This will render the declarations in the `flotiqApi/dist` folder.
 

--- a/cfg.json
+++ b/cfg.json
@@ -13,7 +13,7 @@
     	    "modelPropertyNaming": "original",
     	    "paramNaming": "original",
             "npmName": "FlotiqApi",
-	    "apiNameSuffix":"",
+	    "apiNameSuffix":"API",
 	    "apiNamePrefix":"",
 	    "prefixParameterInterfaces": true
 	},

--- a/index.js
+++ b/index.js
@@ -48,10 +48,12 @@ async function main() {
         // const command = `openapi-generator-cli generate -i ${schemaFile} -g typescript-fetch --additional-properties=apiKey=${apiKey} -o ./generated-api`;
         const genCommand = `openapi-generator-cli --openapitools ${configPath} generate`
         const mvCommand = `mv ${__dirname}/flotiqApi ${outputPath}`;
+        const cleanCommand = `${__dirname}/clean_duplicate_import.sh`;
 
         console.log('Generating client from schema...');
         execSync(genCommand, { stdio: 'ignore', cwd: __dirname});
         execSync(mvCommand, { stdio: 'ignore', cwd: __dirname});
+        execSync(cleanCommand, { stdio: 'ignore', cwd: $outputPath});
         
         console.log('Client generated successfully!');
     } catch (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flotiq-codegen-ts",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "CLI tool to generate API clients using Flotiq API and OpenAPI Generator",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Change classnames of APIs, e.g. from "Product" to "ProductAPI", to make it distinguishable from model classnames.