### PR TITLE
Fix the clean_duplicate_import.sh command to work on Unix/Linux 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ To generate a set of `d.ts` files for Typescript follow these steps:
 
 This will render the declarations in the `flotiqApi/dist` folder.
 
+## Developing
+
+To start developing this project, follow these steps:
+
+1. Clone the repository `git clone git@github.com:flotiq/flotiq-codegen-ts.git` 
+2. Install dependencies `yarn install`
+3. Run the project `yarn start`
+
 ## Collaborating
 
 If you wish to talk with us about this project, feel free to hop on our [![Discord Chat](https://img.shields.io/discord/682699728454025410.svg)](https://discord.gg/FwXcHnX).

--- a/clean_duplicate_import.sh
+++ b/clean_duplicate_import.sh
@@ -7,7 +7,7 @@ escaped_delete_line=$(printf '%s\n' "$delete_line" | sed 's:[][\/.^$*]:\\&:g')
 
 for file in $file_patterns; do
   if grep -Fq "$delete_line" "$file"; then
-    sed -i '' "/$escaped_delete_line/d" "$file"
+    sed -i "/$escaped_delete_line/d" "$file"
   fi
 done
 

--- a/clean_duplicate_import.sh
+++ b/clean_duplicate_import.sh
@@ -7,7 +7,8 @@ escaped_delete_line=$(printf '%s\n' "$delete_line" | sed 's:[][\/.^$*]:\\&:g')
 
 for file in $file_patterns; do
   if grep -Fq "$delete_line" "$file"; then
-    sed -i "/$escaped_delete_line/d" "$file"
+    sed -i.old "/$escaped_delete_line/d" "$file"
+    rm "${file}.old"
   fi
 done
 


### PR DESCRIPTION
Running  `npx flotiq-codegen-ts generate` causes an error:

![1](https://github.com/flotiq/flotiq-codegen-ts/assets/645716/ce33b253-44c7-4fbf-9408-c6854f380ba8)

The issue was caused by using the -i '' option in the sed command. The -i '' option is specific to macOS

- [ ] Removed `''`
- [ ] Improved docs - development section


### Testing

1. Install from branch `npm install git+https://github.com/flotiq/flotiq-codegen-ts.git#hotfix/fix-clean-command-unix`
2. Run npx flotiq-codegen-ts generate


Refs #24629