### PR TITLE
Missing files after command run

### DIFF
--- a/build_to_js.js
+++ b/build_to_js.js
@@ -3,7 +3,7 @@ const {execSync} = require('child_process');
 const buildToJs = (outputPath) => {
 
     // fce.mkdirp('flotiqApiBuildJs').then().catch(err => err && console.error(err));
-    execSync('tsc -p ./flotiqApi', {stdio: 'ignore'});
+    execSync('tsc -p ./flotiqApi', {stdio: 'inherit'});
 
     fce.moveSync('flotiqApi/dist/', 'flotiqApiBuildJs', {overwrite: true});
 

--- a/build_to_js.js
+++ b/build_to_js.js
@@ -1,14 +1,18 @@
 const fce = require('fs-extra');
 const {execSync} = require('child_process');
-const buildToJs = (outputPath) => {
 
-    // fce.mkdirp('flotiqApiBuildJs').then().catch(err => err && console.error(err));
-    execSync('tsc -p ./flotiqApi', {stdio: 'inherit'});
+/**
+ * Move raw TypeScript code to tmp _copy dir
+ * Run compilation
+ * Move back compiled files to standard flotiqApi dir
+ * @param tmpSDKPath
+ */
+const buildToJs = (tmpSDKPath) => {
+    const sdkCopyPath = tmpSDKPath.replace('flotiqApi', 'flotiqApi_copy');
+    fce.moveSync(tmpSDKPath, sdkCopyPath);
 
-    fce.moveSync('flotiqApi/dist/', 'flotiqApiBuildJs', {overwrite: true});
-
-    fce.removeSync('flotiqApi');
-    fce.moveSync("flotiqApiBuildJs", outputPath, {overwrite: true});
+    execSync(`tsc -p ${sdkCopyPath}`, {stdio: 'inherit'});
+    fce.moveSync(`${sdkCopyPath}/dist/`, `${tmpSDKPath}`, {overwrite: true});
 }
 
 module.exports = buildToJs;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const fce = require('fs-extra');
 const path = require('path');
 const dotenv = require('dotenv');
 const yargs = require('yargs');
-const admZip = require('adm-zip')
+const admZip = require('adm-zip');
+const os = require('os');
 const buildToJs = require("./build_to_js");
 const cleanDuplicateImport = require("./clean_duplicate_import");
 
@@ -14,6 +15,8 @@ const compileToJsFlag = "compiled-js";
 
 const CLI_GREEN = "\x1b[32m%s\x1b[0m";
 const CLI_BLUE = "\x1b[36m%s\x1b[0m";
+
+const getWorkingPath = () => fs.mkdtempSync(`${os.tmpdir()}${path.sep}`);
 
 async function lambdaInvoke(url) {
 
@@ -39,7 +42,7 @@ const argv = yargs(process.argv)
     .command("flotiq-codegen-ts generate [options]", "Generate api integration for your Flotiq project", {})
     .usage("Use flotiq-codegen-ts generates typescript Fetch API integration for your Flotiq project.")
     .option(compileToJsFlag, {
-        description: "generates Fetch API integration compiled to JS",
+        description: "Generates Fetch API integration compiled to JavaScript",
         alias: "",
         type: "boolean",
         default: false,
@@ -60,7 +63,13 @@ async function confirm(msg) {
 
 async function main() {
 
-    const envfiles = ['.env', 'env.local', 'env.development'];
+    const envfiles = [
+        '.env',
+        '.env.local',
+        '.env.development',
+        'env.local',
+        'env.development'
+    ];
     const envName = "FLOTIQ_API_KEY";
     let apiKey = ''
     for (const file of envfiles) {
@@ -71,7 +80,7 @@ async function main() {
 
             if (process.env[envName]) {
 
-                query = await confirm(`${envName} found in env file. \n  Do you want to use API key from ${file}?`)
+                query = await confirm(`${envName} found in '${file}' file. \n  Do you want to use API key from ${file}?`)
                 if (query) {
                     //using API key from file
                     apiKey = process.env[envName];
@@ -102,24 +111,27 @@ async function main() {
         // Generate command
         const lambdaUrl = `https://0c8judkapg.execute-api.us-east-1.amazonaws.com/default/codegen-ts?token=${apiKey}`
         const zip = new admZip(await lambdaInvoke(lambdaUrl));
+        const tmpPath = getWorkingPath();
         const outputPath = path.join(process.cwd(), 'flotiqApi');
         console.log('Generating client from schema...');
 
         if (fs.existsSync(outputPath)) {
-            console.log(`Found existing SDK files - cleaning up '${outputPath}' directory...`);
+            console.log(`Found existing SDK in '${outputPath}' - cleaning up...`);
             fce.removeSync(outputPath);
         }
 
-        console.log(`Extracting SDK client to '${outputPath}'...`);
-        zip.extractAllTo(outputPath);
-
-        console.log('Cleaning up generated files...');
-        cleanDuplicateImport(outputPath);
+        console.log(`Extracting SDK client to tmp dir '${tmpPath}'...`);
+        zip.extractAllTo(tmpPath);
+        cleanDuplicateImport(tmpPath);
 
         if (compileToJs) {
             console.log('Compiling to JavaScript...');
-            buildToJs(outputPath);
+            buildToJs(tmpPath);
         }
+
+        console.log(`Moving SDK to project '${outputPath}' directory...`);
+        fce.moveSync(tmpPath, outputPath);
+        fce.removeSync(tmpPath);
 
         console.log(CLI_GREEN, 'Client generated successfully!');
         console.log(CLI_GREEN, 'You can start using Flotiq SDK');

--- a/index.js
+++ b/index.js
@@ -114,12 +114,16 @@ async function main() {
             return;
         }
 
+        console.log(`Extracting files to ${localPath}`);
         zip.extractAllTo(localPath)
+        console.log(`Extracted ${localPath}`);
+        execSync('ls -l', {stdio: 'ignore'});
 
-        console.log('Compiling to javascript...');
+        console.log('Cleaning duplicates');
         cleanDuplicateImport(localPath);
+        execSync('ls -l', {stdio: 'ignore'});
+        console.log('Compiling to javascript...');
         buildToJs(localPath);
-
         console.log('Client generated successfully!');
 
     } catch (error) {

--- a/index.js
+++ b/index.js
@@ -114,16 +114,16 @@ async function main() {
             return;
         }
 
-        console.log(`Extracting files to ${localPath}`);
-        zip.extractAllTo(localPath)
-        console.log(`Extracted ${localPath}`);
+        console.log(`Extracting files to ${outputPath}`);
+        zip.extractAllTo(outputPath)
+        console.log(`Extracted ${outputPath}`);
         execSync('ls -l', {stdio: 'ignore'});
 
         console.log('Cleaning duplicates');
-        cleanDuplicateImport(localPath);
+        cleanDuplicateImport(outputPath);
         execSync('ls -l', {stdio: 'ignore'});
         console.log('Compiling to javascript...');
-        buildToJs(localPath);
+        buildToJs(outputPath);
         console.log('Client generated successfully!');
 
     } catch (error) {

--- a/index.js
+++ b/index.js
@@ -106,19 +106,13 @@ async function main() {
     const compileToJs = argv[compileToJsFlag];
 
     try {
-        console.log('Downloading OpenAPI schema...');
+        console.log('Generating client from schema...');
 
         // Generate command
         const lambdaUrl = `https://0c8judkapg.execute-api.us-east-1.amazonaws.com/default/codegen-ts?token=${apiKey}`
         const zip = new admZip(await lambdaInvoke(lambdaUrl));
         const tmpPath = getWorkingPath();
         const outputPath = path.join(process.cwd(), 'flotiqApi');
-        console.log('Generating client from schema...');
-
-        if (fs.existsSync(outputPath)) {
-            console.log(`Found existing SDK in '${outputPath}' - cleaning up...`);
-            fce.removeSync(outputPath);
-        }
 
         console.log(`Extracting SDK client to tmp dir '${tmpPath}'...`);
         zip.extractAllTo(tmpPath);
@@ -129,12 +123,17 @@ async function main() {
             buildToJs(tmpPath);
         }
 
-        console.log(`Moving SDK to project '${outputPath}' directory...`);
+        if (fs.existsSync(outputPath)) {
+            console.log(`Found existing SDK in '${outputPath}' - cleaning up...`);
+            fce.removeSync(outputPath);
+        }
+
+        console.log(`Moving SDK to '${outputPath}'...`);
         fce.moveSync(tmpPath, outputPath);
         fce.removeSync(tmpPath);
 
         console.log(CLI_GREEN, 'Client generated successfully!');
-        console.log(CLI_GREEN, 'You can start using Flotiq SDK');
+        console.log(CLI_GREEN, 'You can start using your Flotiq SDK');
         console.log(CLI_BLUE, 'Read more: https://github.com/flotiq/flotiq-codegen-ts');
 
     } catch (error) {

--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ async function main() {
                 if (query) {
                     //using API key from file
                     apiKey = process.env[envName];
+                    break;
                 }
             }
         }

--- a/index.js
+++ b/index.js
@@ -112,15 +112,16 @@ async function main() {
         const lambdaUrl = `https://0c8judkapg.execute-api.us-east-1.amazonaws.com/default/codegen-ts?token=${apiKey}`
         const zip = new admZip(await lambdaInvoke(lambdaUrl));
         const tmpPath = getWorkingPath();
+        const tmpSDKPath = `${tmpPath}/flotiqApi`;
         const outputPath = path.join(process.cwd(), 'flotiqApi');
 
         console.log(`Extracting SDK client to tmp dir '${tmpPath}'...`);
-        zip.extractAllTo(tmpPath);
-        cleanDuplicateImport(tmpPath);
+        zip.extractAllTo(tmpSDKPath);
+        cleanDuplicateImport(tmpSDKPath);
 
         if (compileToJs) {
             console.log('Compiling to JavaScript...');
-            buildToJs(tmpPath);
+            buildToJs(tmpSDKPath);
         }
 
         if (fs.existsSync(outputPath)) {
@@ -129,7 +130,7 @@ async function main() {
         }
 
         console.log(`Moving SDK to '${outputPath}'...`);
-        fce.moveSync(tmpPath, outputPath);
+        fce.moveSync(tmpSDKPath, outputPath);
         fce.removeSync(tmpPath);
 
         console.log(CLI_GREEN, 'Client generated successfully!');

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "adm-zip": "^0.5.12",
     "axios": "^1.6.8",
     "dotenv": "^16.4.5",
+    "fs-extra": "^11.2.0",
     "inquirer": "^8.2.0",
     "typescript": "^4.0",
     "yargs": "^15.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flotiq-codegen-ts",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "CLI tool to generate API clients using Flotiq API and OpenAPI Generator",
   "main": "index.js",
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,6 +390,15 @@ fs-extra@10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
+  integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"


### PR DESCRIPTION
Description:
Running 

```
michal@DESKTOP-SKG77NC:~/projects/flotiq-nextjs-blog-1$ npx flotiq-codegen-ts generate --compiled-js
? FLOTIQ_API_KEY found in env file. 
  Do you want to use API key from .env? Yes
Downloading OpenAPI schema...
Generating client from schema...
Compiling to javascript...
An error occurred: Error: Command failed: tsc -p ./flotiqApi
    at checkExecSyncError (node:child_process:890:11)
    at execSync (node:child_process:962:15)
    at buildToJs (/home/michal/.npm/_npx/1531fb1c99eef8a5/node_modules/flotiq-codegen-ts/build_to_js.js:6:5)
    at main (/home/michal/.npm/_npx/1531fb1c99eef8a5/node_modules/flotiq-codegen-ts/index.js:121:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
```
Causes tsc error.
After debugging - there was no files in output directory before tsc command.

Changes:
- Add more output to compile fn
- *Output files to cwd path, not localpath*
- Cleanup command, add additional output
- Use tmp dir

Testing:
`npm install git+https://github.com/flotiq/flotiq-codegen-ts.git#hotfix/tsc-error`


Refs #24775 #24776