### PR TITLE
add ability to change SDK output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ npx flotiq-codegen-ts generate --silent
 
 This is especially useful when you are using generator with other automation tools or you are running generate function by hand.
 
+## Changing SDK output path
+
+By default, the SDK is generated in the `flotiqApi` folder in your working directory.
+
+If you want to change the path for the generated SDK, use the `--output`/`-o` option with your chosen path.
+
+```bash
+npx flotiq-codegen-ts generate --output ./lib/flotiqApi
+```
+
+In the example above, the SDK will be placed in the `flotiqApi` folder within `lib` in your working directory.
+
 ## Node.js api
 
 You can use command handler in your scripts by importing command handler

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flotiq-codegen-ts",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "CLI tool to generate API clients using Flotiq API and OpenAPI Generator",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Added new option to change the path for generated SDK. 

To change the path, use `--output`/`-o` option.
