### PR TITLE
Fix missing outputPath parameter when in watch mode

### DIFF
--- a/commands/generate.js
+++ b/commands/generate.js
@@ -141,7 +141,7 @@ async function main(argv) {
     loader.start();
     await watchChanges(apiKey, compileToJs, logger, outputPath);
     setInterval(
-        () => watchChanges(apiKey, compileToJs, logger),
+        () => watchChanges(apiKey, compileToJs, logger, outputPath),
         watchInterval,
         apiKey,
         compileToJs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flotiq-codegen-ts",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "CLI tool to generate API clients using Flotiq API and OpenAPI Generator",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Currently in watch mode, sdk generation causes exception after changes are made. This PR fixes this issue.